### PR TITLE
Add media utils tests

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,19 +1,7 @@
 import React, { useRef, useState } from "react";
 import { ReactComponent as BentleyLogo } from "./assets/bentley-logo.svg";
 import BillboardScene from "./BillboardScene";
-
-const is360Image = (file) => {
-  // Heuristic: filename contains '360' or 'pano', or user marks it
-  return file && file.name && /360|pano/i.test(file.name);
-};
-
-const isVideo = (file) => {
-  return file && file.type && file.type.startsWith("video/");
-};
-
-const isImage = (file) => {
-  return file && file.type && file.type.startsWith("image/");
-};
+import { is360Image, isVideo, isImage } from "./mediaUtils";
 
 function App() {
   // Groups: [{ name: string, media: [File, ...] }]

--- a/src/__tests__/mediaUtils.test.js
+++ b/src/__tests__/mediaUtils.test.js
@@ -1,0 +1,57 @@
+import { is360Image, isVideo, isImage } from '../mediaUtils';
+
+describe('mediaUtils helpers', () => {
+  describe('is360Image', () => {
+    it('detects names containing 360', () => {
+      const file = { name: 'myphoto_360.jpg' };
+      expect(is360Image(file)).toBe(true);
+    });
+
+    it('detects names containing pano (case-insensitive)', () => {
+      const file = { name: 'Vacation-PANO.PNG' };
+      expect(is360Image(file)).toBe(true);
+    });
+
+    it('returns false for non matching names', () => {
+      const file = { name: 'regular.jpg' };
+      expect(is360Image(file)).toBe(false);
+    });
+
+    it('handles missing input gracefully', () => {
+      expect(is360Image()).toBe(false);
+      expect(is360Image(null)).toBe(false);
+      expect(is360Image({})).toBe(false);
+    });
+  });
+
+  describe('isVideo', () => {
+    it('returns true for video mime types', () => {
+      expect(isVideo({ type: 'video/mp4' })).toBe(true);
+    });
+
+    it('returns false for non video mime types', () => {
+      expect(isVideo({ type: 'image/png' })).toBe(false);
+    });
+
+    it('handles missing input gracefully', () => {
+      expect(isVideo()).toBe(false);
+      expect(isVideo({})).toBe(false);
+    });
+  });
+
+  describe('isImage', () => {
+    it('returns true for image mime types', () => {
+      expect(isImage({ type: 'image/jpeg' })).toBe(true);
+      expect(isImage({ type: 'image/png' })).toBe(true);
+    });
+
+    it('returns false for non image mime types', () => {
+      expect(isImage({ type: 'video/webm' })).toBe(false);
+    });
+
+    it('handles missing input gracefully', () => {
+      expect(isImage()).toBe(false);
+      expect(isImage({})).toBe(false);
+    });
+  });
+});

--- a/src/mediaUtils.js
+++ b/src/mediaUtils.js
@@ -1,0 +1,12 @@
+export const is360Image = (file) => {
+  // Heuristic: filename contains '360' or 'pano', or user marks it
+  return !!(file && file.name && /360|pano/i.test(file.name));
+};
+
+export const isVideo = (file) => {
+  return !!(file && file.type && file.type.startsWith('video/'));
+};
+
+export const isImage = (file) => {
+  return !!(file && file.type && file.type.startsWith('image/'));
+};


### PR DESCRIPTION
## Summary
- expose media helper utilities in `mediaUtils.js`
- update `App.js` to use the extracted helpers
- add Jest tests for the helpers

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_6848fa0ec8ec833096949ce5da8ed78d