### PR TITLE
Add manual 360° toggle for media

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,7 +4,8 @@ import BillboardScene from "./BillboardScene";
 
 const is360Image = (file) => {
   // Heuristic: filename contains '360' or 'pano', or user marks it
-  return file && file.name && /360|pano/i.test(file.name);
+  if (!file) return false;
+  return file.userMarked360 || (file.name && /360|pano/i.test(file.name));
 };
 
 const isVideo = (file) => {
@@ -44,7 +45,10 @@ function App() {
 
   // Add files to current group
   const handleFileChange = (e) => {
-    const files = Array.from(e.target.files);
+    const files = Array.from(e.target.files).map(f => {
+      f.userMarked360 = false;
+      return f;
+    });
     if (!files.length) return;
     setGroups((prev) => {
       const updated = [...prev];
@@ -119,6 +123,23 @@ function App() {
       return updated;
     });
     setRenaming(false);
+  };
+
+  const toggleCurrentMark360 = () => {
+    setGroups((prev) => {
+      const updated = [...prev];
+      const group = { ...updated[selectedGroupIdx] };
+      const media = [...group.media];
+      if (!media[currentIdx]) return prev;
+      media[currentIdx].userMarked360 = !media[currentIdx].userMarked360;
+      group.media = media;
+      updated[selectedGroupIdx] = group;
+      return updated;
+    });
+    if (psv) {
+      psv.destroy();
+      setPsv(null);
+    }
   };
 
 
@@ -319,6 +340,15 @@ function App() {
         {currentGroup.media.length > 0 && (
           <>
             {currentIdx + 1} / {currentGroup.media.length} : {currentGroup.media[currentIdx].name}
+            <label style={{ marginLeft: 10 }}>
+              <input
+                type="checkbox"
+                checked={!!currentGroup.media[currentIdx].userMarked360}
+                onChange={toggleCurrentMark360}
+                style={{ marginRight: 4 }}
+              />
+              360°
+            </label>
           </>
         )}
       </div>


### PR DESCRIPTION
## Summary
- allow marking individual files as 360° using a checkbox
- check the `userMarked360` flag in the `is360Image` helper

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: react-scripts test interactive runner didn't execute in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6848f662cc308330ad78ab4a1d80cb1d