### PR TITLE
Fix file input reset

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -61,6 +61,8 @@ function App() {
       psv.destroy();
       setPsv(null);
     }
+    // Reset input so selecting the same file triggers onChange again
+    e.target.value = "";
   };
 
   // Add a new group


### PR DESCRIPTION
## Summary
- reset file input element after processing selected files so the same file can trigger `onChange` again

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_e_6848f5430404833095edc89ef1bea8b3