### PR TITLE
Add server to fetch inventory from Neon/Redis

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,12 @@ A browser-based slideshow app for Firestick and other smart TVs. Supports:
 ## Local Development
 ```sh
 npm install
+npm run server &
 npm start
 ```
+
+The server reads `NEON_DB_URL` or `REDIS_URL` from a `.env` file to load
+inventory data. The React app fetches `/inventory` on startup and uses the
+returned list of `{name, url, type}` records as a slideshow group.
 
 ---

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "server": "node server.js"
   },
   "dependencies": {
     "@react-three/drei": "^9.56.15",
@@ -16,7 +17,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-scripts": "^5.0.1",
-    "three": "^0.150.1"
+    "three": "^0.150.1",
+    "express": "^4.18.2",
+    "pg": "^8.11.3",
+    "redis": "^4.6.7",
+    "dotenv": "^16.3.1"
   },
   "browserslist": {
     "production": [

--- a/server.js
+++ b/server.js
@@ -1,0 +1,51 @@
+const express = require('express');
+const { Pool } = require('pg');
+const { createClient } = require('redis');
+require('dotenv').config();
+
+const app = express();
+const port = process.env.PORT || 3001;
+
+async function fetchFromPostgres() {
+  const pool = new Pool({ connectionString: process.env.NEON_DB_URL });
+  try {
+    const res = await pool.query('SELECT name, url, type FROM inventory ORDER BY id');
+    return res.rows;
+  } finally {
+    await pool.end();
+  }
+}
+
+async function fetchFromRedis() {
+  const client = createClient({ url: process.env.REDIS_URL });
+  await client.connect();
+  try {
+    const items = await client.lRange('inventory', 0, -1);
+    return items.map((item) => JSON.parse(item));
+  } finally {
+    await client.quit();
+  }
+}
+
+app.get('/inventory', async (req, res) => {
+  try {
+    if (process.env.REDIS_URL) {
+      const data = await fetchFromRedis();
+      res.json(data);
+      return;
+    }
+    if (process.env.NEON_DB_URL) {
+      const data = await fetchFromPostgres();
+      res.json(data);
+      return;
+    }
+    res.json([]);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch inventory' });
+  }
+});
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});

--- a/src/BillboardScene.js
+++ b/src/BillboardScene.js
@@ -12,13 +12,15 @@ function Billboard({ media }) {
   useEffect(() => {
     if (!media) return;
     if (media.type && media.type.startsWith("image/")) {
-      const url = URL.createObjectURL(media);
-      const tex = new TextureLoader().load(url, () => URL.revokeObjectURL(url));
+      const url = media.url || URL.createObjectURL(media);
+      const tex = new TextureLoader().load(url, () => {
+        if (!media.url) URL.revokeObjectURL(url);
+      });
       setTexture(tex);
       setVideoEl(null);
     } else if (media.type && media.type.startsWith("video/")) {
       const video = document.createElement("video");
-      video.src = URL.createObjectURL(media);
+      video.src = media.url || URL.createObjectURL(media);
       video.crossOrigin = "anonymous";
       video.loop = true;
       video.muted = true;
@@ -36,7 +38,7 @@ function Billboard({ media }) {
     return () => {
       if (videoEl) {
         videoEl.pause();
-        URL.revokeObjectURL(videoEl.src);
+        if (!media.url) URL.revokeObjectURL(videoEl.src);
       }
     };
     // eslint-disable-next-line


### PR DESCRIPTION
## Summary
- add Express server with /inventory endpoint using Neon Postgres or Redis
- update README with server instructions
- load remote inventory group in React app
- support remote URLs in media helpers
- allow BillboardScene to display remote assets

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68488bccbaa08330a4ddf552b29c424d