### PR TITLE
Fix inventory loading without Redis

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -176,44 +176,17 @@ function App() {
   
   const loadInventory = async () => {
     try {
-      console.log('Fetching /api/inventory...');
       const res = await fetch('/api/inventory');
-      console.log('Response from /api/inventory:', res);
-
       if (!res.ok) {
         throw new Error(`HTTP error! status: ${res.status}`);
       }
 
       const items = await res.json();
-      console.log('Received inventory items:', items);
-
       if (!Array.isArray(items)) {
         throw new Error('Inventory data is not an array');
       }
 
-      const files = await Promise.all(
-        items.map(async (item) => {
-          try {
-            console.log(`Fetching item.url: ${item.url}`);
-            const r = await fetch(item.url);
-            if (!r.ok) {
-              throw new Error(`Failed to fetch ${item.url}, status: ${r.status}`);
-            }
-            const blob = await r.blob();
-            return new File([blob], item.name, { type: item.type });
-          } catch (err) {
-            console.error(`Failed to process item: ${item.name}`, item, err);
-            // Return null or some indicator of failure
-            return null;
-          }
-        })
-      );
-      
-      // Filter out any items that failed to load
-      const validFiles = files.filter(file => file !== null);
-
-      console.log('Successfully loaded files:', validFiles);
-      setGroups((prev) => [...prev, { name: 'Inventory', media: validFiles }]);
+      setGroups((prev) => [...prev, { name: 'Inventory', media: items }]);
       setSelectedGroupIdx(groups.length);
     } catch (err) {
       console.error('Failed to load inventory', err);


### PR DESCRIPTION
## Summary
- make Redis optional in the API server so PostgreSQL can be used alone
- simplify `loadInventory` on the frontend to directly use `/api/inventory`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684b8da6274c83309902fe9db4db68b7